### PR TITLE
Release: add musl-tools for C/C++ deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,10 @@ jobs:
       with:
         toolchain: stable
         target: x86_64-unknown-linux-musl
+    - name: Install musl dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install musl-tools
     - name: Build
       uses: actions-rs/cargo@v1
       with:


### PR DESCRIPTION
Address https://github.com/jakobnissen/alen/issues/14#issuecomment-3103488538

I think all deps previously were pure Rust, so there was no need for the musl compiler shim to be installed, but `zstd-sys` is a C++ codebase and need it during build...

This solutions follows what  `dist` does when building a musl binary: https://github.com/axodotdev/cargo-dist/actions/runs/16461649970/job/46530121367#step:7:1