### PR TITLE
Add DNA to protein translation toggle (t key)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ __Commands__
 
 * `Esc / q / Ctrl-C`: Quit
 * `c`: Toggle consensus sequence comparison
+* `t`: Toggle DNA to protein translation (DNA alignments only)
 * `r`: Re-render the screen.
 * `Ctrl-f`: Find. Searches headers, then sequences for regex, case insensitively.
 * `Ctrl-j`: Jump to column.

--- a/src/data.rs
+++ b/src/data.rs
@@ -430,8 +430,8 @@ pub struct View {
     pub colstart: usize,
     pub term_nrows: u16, // obtained from terminal
     pub term_ncols: u16,
-    pub namewidth: u16,  // number of graphemes of each name displayed
-    pub consensus: bool, // if consensus view is shown
+    pub namewidth: u16,   // number of graphemes of each name displayed
+    pub consensus: bool,  // if consensus view is shown
     pub translated: bool, // if showing translated protein view (DNA only)
     aln: Alignment,
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -311,16 +311,10 @@ impl Alignment {
     }
 
     /// Reorder the vectors of the alignment such that similar rows are next to each other.
-    fn sort_and_set_order(&mut self) {
-        self.entries
-            .sort_unstable_by(|a, b| a.original_index.cmp(&b.original_index));
-
+    fn compute_order(&self) -> Vec<u32> {
         // If already ordered or 2 or fewer rows, ordering doesn't matter
         if self.nrows() < 3 {
-            let _ = self
-                .order
-                .set((0..(self.nrows().try_into().unwrap())).collect());
-            return;
+            return (0..(self.nrows().try_into().unwrap())).collect();
         }
 
         // Choices only appear when placing the 3rd seq, so first two are given.
@@ -385,14 +379,11 @@ impl Alignment {
             ord[*o] = i.try_into().unwrap()
         }
 
-        let _ = self.order.set(ord);
+        ord
     }
 
     fn order(&mut self) {
-        if self.order.get().is_none() {
-            self.sort_and_set_order()
-        }
-        let order = self.order.get().unwrap();
+        let order = self.order.get_or_init(|| self.compute_order());
         self.entries
             .sort_unstable_by(|a, b| order[a.original_index].cmp(&order[b.original_index]));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 
 mod constants;
 mod data;
+mod translate;
 
 use constants::HEADER_LINES;
 use data::{Graphemes, View};
@@ -89,12 +90,13 @@ fn draw_footer_text<T: Write>(
 }
 
 fn draw_default_footer<T: Write>(io: &mut TerminalIO<T>, view: &View) -> Result<()> {
-    draw_footer_text(
-        io,
-        view,
-        "q/Esc: Quit | [^⇧] + ←/→/↑/↓: Move | ./,: Adjust names | ^f: Find | ^j: Jump | ^s: Select | c: Consensus | r: Redraw",
-        Color::Grey,
-    )
+    let base_footer = "q/Esc: Quit | [^⇧] + ←/→/↑/↓: Move | ./,: Adjust names | ^f: Find | ^j: Jump | ^s: Select | c: Consensus";
+    let footer = if view.can_translate() {
+        format!("{} | t: Translate | r: Redraw", base_footer)
+    } else {
+        format!("{} | r: Redraw", base_footer)
+    };
+    draw_footer_text(io, view, &footer, Color::Grey)
 }
 
 fn draw_select_footer<T: Write>(io: &mut TerminalIO<T>, view: &View) -> Result<()> {
@@ -298,8 +300,13 @@ fn draw_nonconsensus_sequences<T: Write>(io: &mut TerminalIO<T>, view: &View) ->
 
     for (i, alnrow) in row_range.enumerate() {
         let termrow = (i + HEADER_LINES) as u16;
-        let seq = &view.seq(alnrow).unwrap()[col_range.clone()];
-        draw_sequence(io, view.namewidth + 1, view.is_aa(), seq, termrow)?;
+        let (seq, is_aa): (&[u8], bool) = if view.translated {
+            // Use translated protein sequences
+            (&view.translated_seq(alnrow).unwrap()[col_range.clone()], true)
+        } else {
+            (&view.seq(alnrow).unwrap()[col_range.clone()], view.is_aa())
+        };
+        draw_sequence(io, view.namewidth + 1, is_aa, seq, termrow)?;
     }
     Ok(())
 }
@@ -330,18 +337,24 @@ fn draw_consensus_sequences<T: Write>(io: &mut TerminalIO<T>, view: &View) -> Re
         None => return Ok(()),
     };
 
+    // Determine if we're in amino acid mode (either native AA or translated DNA)
+    let is_aa = view.is_aa() || view.translated;
+
     // First draw top row
     let x = view.consensus().unwrap();
     let cons_seq = &x[col_range.clone()];
-    //let cons_seq = &view.consensus().unwrap().as_ref()[col_range.clone()];
-    draw_top_consensus(io, view.namewidth + 1, view.is_aa(), cons_seq)?;
+    draw_top_consensus(io, view.namewidth + 1, is_aa, cons_seq)?;
 
     // Then draw rest, if applicable
     if let Some(alnrows) = view.seq_row_range() {
         for (i, alnrow) in alnrows.enumerate() {
             let termrow = (i + HEADER_LINES + 1) as u16;
-            let seq = &view.seq(alnrow).unwrap()[col_range.clone()];
-            draw_consensus_other_seq(io, view.namewidth + 1, termrow, view.is_aa(), seq, cons_seq)?
+            let seq: &[u8] = if view.translated {
+                &view.translated_seq(alnrow).unwrap()[col_range.clone()]
+            } else {
+                &view.seq(alnrow).unwrap()[col_range.clone()]
+            };
+            draw_consensus_other_seq(io, view.namewidth + 1, termrow, is_aa, seq, cons_seq)?
         }
     }
     Ok(())
@@ -697,6 +710,45 @@ fn default_loop<T: Write>(io: &mut TerminalIO<T>, view: &mut View) -> Result<()>
                     draw_default_mode_screen(io, view)?;
                     continue;
                 };
+
+                // Toggle translation view (DNA only)
+                if kevent == KeyEvent::new(KeyCode::Char('t'), event::KeyModifiers::NONE)
+                    || kevent == KeyEvent::new(KeyCode::Char('T'), event::KeyModifiers::NONE)
+                {
+                    if view.can_translate() {
+                        // Calculate translation if not done yet
+                        if view.translated_seqs().is_none() {
+                            execute!(
+                                io.io,
+                                ResetColor,
+                                terminal::Clear(ClearType::All),
+                                cursor::MoveTo(0, 0),
+                                Print("Translating sequences..."),
+                            )?;
+                            view.calculate_translation()
+                        }
+
+                        // Toggle translation mode
+                        view.translated = !view.translated;
+
+                        // Adjust column position: 3 DNA bases = 1 amino acid
+                        if view.translated {
+                            view.colstart /= 3;
+                        } else {
+                            view.colstart *= 3;
+                        }
+
+                        // Clear consensus when switching modes (different alphabets)
+                        if view.consensus {
+                            view.consensus = false;
+                            view.clear_consensus();
+                            view.move_view(-1, 0);
+                        }
+
+                        draw_default_mode_screen(io, view)?;
+                        continue;
+                    }
+                };
             }
             Event::Resize(ncols, nrows) => {
                 view.resize(ncols, nrows);
@@ -838,7 +890,13 @@ fn search_loop<T: Write>(io: &mut TerminalIO<T>, view: &mut View) -> Result<()> 
                         let seq_col =
                             start.saturating_sub(view.colstart) as u16 + (view.namewidth + 1);
                         let highlight_str = unsafe {
-                            std::str::from_utf8_unchecked(&view.seq(row).unwrap()[start..stop])
+                            if view.translated {
+                                std::str::from_utf8_unchecked(
+                                    &view.translated_seq(row).unwrap()[start..stop],
+                                )
+                            } else {
+                                std::str::from_utf8_unchecked(&view.seq(row).unwrap()[start..stop])
+                            }
                         };
                         draw_highlight(io, seq_row, seq_col, view.term_ncols, highlight_str)?;
                         select_loop(io, view, row)?;
@@ -879,17 +937,30 @@ fn search_query(view: &View, query: &str) -> SearchResult {
         }
     }
 
-    // Then search the sequences
-    for (rowno, seq) in view.seqs().enumerate() {
-        // We have checked on instantiation that this is OK, and do not provide
-        // any functionality to mutate the sequences
-        let string = unsafe { std::str::from_utf8_unchecked(seq) };
-        if let Some(regex_match) = re.find(string) {
-            return SearchResult::MatchSeq {
-                row: rowno,
-                start: regex_match.start(),
-                stop: regex_match.end(),
-            };
+    // Then search the sequences (use translated if in translated mode)
+    if view.translated {
+        for (rowno, seq) in view.translated_seqs().unwrap().iter().enumerate() {
+            let string = unsafe { std::str::from_utf8_unchecked(seq) };
+            if let Some(regex_match) = re.find(string) {
+                return SearchResult::MatchSeq {
+                    row: rowno,
+                    start: regex_match.start(),
+                    stop: regex_match.end(),
+                };
+            }
+        }
+    } else {
+        for (rowno, seq) in view.seqs().enumerate() {
+            // We have checked on instantiation that this is OK, and do not provide
+            // any functionality to mutate the sequences
+            let string = unsafe { std::str::from_utf8_unchecked(seq) };
+            if let Some(regex_match) = re.find(string) {
+                return SearchResult::MatchSeq {
+                    row: rowno,
+                    start: regex_match.start(),
+                    stop: regex_match.end(),
+                };
+            }
         }
     }
     SearchResult::NoMatch

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1,0 +1,117 @@
+/// Universal genetic code translation table.
+/// Codon index: (base1 * 16) + (base2 * 4) + base3
+/// where A=0, C=1, G=2, T/U=3
+const CODON_TABLE: [u8; 64] = [
+    b'K', b'N', b'K', b'N', // AAA, AAC, AAG, AAT
+    b'T', b'T', b'T', b'T', // ACA, ACC, ACG, ACT
+    b'R', b'S', b'R', b'S', // AGA, AGC, AGG, AGT
+    b'I', b'I', b'M', b'I', // ATA, ATC, ATG, ATT
+    b'Q', b'H', b'Q', b'H', // CAA, CAC, CAG, CAT
+    b'P', b'P', b'P', b'P', // CCA, CCC, CCG, CCT
+    b'R', b'R', b'R', b'R', // CGA, CGC, CGG, CGT
+    b'L', b'L', b'L', b'L', // CTA, CTC, CTG, CTT
+    b'E', b'D', b'E', b'D', // GAA, GAC, GAG, GAT
+    b'A', b'A', b'A', b'A', // GCA, GCC, GCG, GCT
+    b'G', b'G', b'G', b'G', // GGA, GGC, GGG, GGT
+    b'V', b'V', b'V', b'V', // GTA, GTC, GTG, GTT
+    b'*', b'Y', b'*', b'Y', // TAA, TAC, TAG, TAT (stop codons = *)
+    b'S', b'S', b'S', b'S', // TCA, TCC, TCG, TCT
+    b'*', b'C', b'W', b'C', // TGA, TGC, TGG, TGT (TGA = stop)
+    b'L', b'F', b'L', b'F', // TTA, TTC, TTG, TTT
+];
+
+fn base_to_index(base: u8) -> Option<usize> {
+    match base | 0x20 {
+        // lowercase conversion
+        b'a' => Some(0),
+        b'c' => Some(1),
+        b'g' => Some(2),
+        b't' | b'u' => Some(3),
+        _ => None,
+    }
+}
+
+/// Translate a 3-base codon to an amino acid.
+/// Returns '-' if codon contains any gap, 'X' for ambiguous/unknown bases.
+pub fn translate_codon(codon: &[u8]) -> u8 {
+    if codon.len() != 3 {
+        return b'X';
+    }
+
+    // Check for gaps
+    if codon.iter().any(|&b| b == b'-') {
+        return b'-';
+    }
+
+    let b1 = match base_to_index(codon[0]) {
+        Some(i) => i,
+        None => return b'X',
+    };
+    let b2 = match base_to_index(codon[1]) {
+        Some(i) => i,
+        None => return b'X',
+    };
+    let b3 = match base_to_index(codon[2]) {
+        Some(i) => i,
+        None => return b'X',
+    };
+
+    CODON_TABLE[b1 * 16 + b2 * 4 + b3]
+}
+
+/// Translate a DNA sequence to protein.
+/// Assumes sequence is in-frame (starts at codon position 0).
+/// Truncates to complete codons.
+pub fn translate_sequence(seq: &[u8]) -> Vec<u8> {
+    let protein_len = seq.len() / 3;
+    let mut protein = Vec::with_capacity(protein_len);
+
+    for i in 0..protein_len {
+        let codon = &seq[i * 3..i * 3 + 3];
+        protein.push(translate_codon(codon));
+    }
+
+    protein
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_translate_codon() {
+        // Standard codons
+        assert_eq!(translate_codon(b"ATG"), b'M'); // Start codon
+        assert_eq!(translate_codon(b"TAA"), b'*'); // Stop
+        assert_eq!(translate_codon(b"TAG"), b'*'); // Stop
+        assert_eq!(translate_codon(b"TGA"), b'*'); // Stop
+        assert_eq!(translate_codon(b"TTT"), b'F'); // Phe
+        assert_eq!(translate_codon(b"GGG"), b'G'); // Gly
+
+        // Case insensitive
+        assert_eq!(translate_codon(b"atg"), b'M');
+        assert_eq!(translate_codon(b"AtG"), b'M');
+
+        // U instead of T (RNA)
+        assert_eq!(translate_codon(b"AUG"), b'M');
+
+        // Gaps
+        assert_eq!(translate_codon(b"A-G"), b'-');
+        assert_eq!(translate_codon(b"---"), b'-');
+
+        // Ambiguous bases
+        assert_eq!(translate_codon(b"ATN"), b'X');
+        assert_eq!(translate_codon(b"NNN"), b'X');
+    }
+
+    #[test]
+    fn test_translate_sequence() {
+        assert_eq!(translate_sequence(b"ATGTTT"), b"MF");
+        assert_eq!(translate_sequence(b"ATGTTTGGG"), b"MFG");
+        // Partial codon at end is truncated
+        assert_eq!(translate_sequence(b"ATGTTTT"), b"MF");
+        assert_eq!(translate_sequence(b"ATGTTTTT"), b"MF");
+        // Gaps
+        assert_eq!(translate_sequence(b"ATG---TTT"), b"M-F");
+    }
+}

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -64,7 +64,7 @@ pub fn translate_codon(codon: [u8; 3]) -> Result<u8, TranslationError> {
     // Check for gaps - must be all gaps or no gaps
     let gap_count = codon.iter().filter(|&&b| b == b'-').count();
     match gap_count {
-        0 => {} // No gaps, continue to translation
+        0 => {}               // No gaps, continue to translation
         3 => return Ok(b'-'), // All gaps
         _ => return Err(TranslationError::MixedGapCodon { position: 0 }), // Mixed gaps - error
     }

--- a/src/translate.rs
+++ b/src/translate.rs
@@ -1,3 +1,29 @@
+use std::fmt;
+
+/// Error type for translation failures
+#[derive(Debug, Clone)]
+pub enum TranslationError {
+    /// A codon contains a mix of gaps and non-gaps (e.g., "A-G")
+    /// This is invalid because the ungapped sequence would translate differently
+    MixedGapCodon { position: usize },
+}
+
+impl fmt::Display for TranslationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TranslationError::MixedGapCodon { position } => {
+                write!(
+                    f,
+                    "Mixed gap codon at position {} (gaps must align with codon boundaries)",
+                    position + 1 // 1-indexed for display
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for TranslationError {}
+
 /// Universal genetic code translation table.
 /// Codon index: (base1 * 16) + (base2 * 4) + base3
 /// where A=0, C=1, G=2, T/U=3
@@ -32,46 +58,57 @@ fn base_to_index(base: u8) -> Option<usize> {
 }
 
 /// Translate a 3-base codon to an amino acid.
-/// Returns '-' if codon contains any gap, 'X' for ambiguous/unknown bases.
-pub fn translate_codon(codon: &[u8]) -> u8 {
-    if codon.len() != 3 {
-        return b'X';
-    }
-
-    // Check for gaps
-    if codon.iter().any(|&b| b == b'-') {
-        return b'-';
+/// Returns '-' if codon is all gaps, 'X' for ambiguous/unknown bases.
+/// Returns error if codon has mixed gaps (some gaps, some non-gaps).
+pub fn translate_codon(codon: [u8; 3]) -> Result<u8, TranslationError> {
+    // Check for gaps - must be all gaps or no gaps
+    let gap_count = codon.iter().filter(|&&b| b == b'-').count();
+    match gap_count {
+        0 => {} // No gaps, continue to translation
+        3 => return Ok(b'-'), // All gaps
+        _ => return Err(TranslationError::MixedGapCodon { position: 0 }), // Mixed gaps - error
     }
 
     let b1 = match base_to_index(codon[0]) {
         Some(i) => i,
-        None => return b'X',
+        None => return Ok(b'X'),
     };
     let b2 = match base_to_index(codon[1]) {
         Some(i) => i,
-        None => return b'X',
+        None => return Ok(b'X'),
     };
     let b3 = match base_to_index(codon[2]) {
         Some(i) => i,
-        None => return b'X',
+        None => return Ok(b'X'),
     };
 
-    CODON_TABLE[b1 * 16 + b2 * 4 + b3]
+    Ok(CODON_TABLE[b1 * 16 + b2 * 4 + b3])
 }
 
 /// Translate a DNA sequence to protein.
 /// Assumes sequence is in-frame (starts at codon position 0).
-/// Truncates to complete codons.
-pub fn translate_sequence(seq: &[u8]) -> Vec<u8> {
-    let protein_len = seq.len() / 3;
+/// Partial codons at the end are translated to 'X'.
+/// Returns error if any codon contains mixed gaps.
+pub fn translate_sequence(seq: &[u8]) -> Result<Vec<u8>, TranslationError> {
+    let protein_len = seq.len().div_ceil(3);
     let mut protein = Vec::with_capacity(protein_len);
 
-    for i in 0..protein_len {
-        let codon = &seq[i * 3..i * 3 + 3];
-        protein.push(translate_codon(codon));
+    // TODO: Use array_chunks when stabilized
+    for (i, chunk) in seq.chunks(3).enumerate() {
+        if chunk.len() == 3 {
+            let codon: [u8; 3] = chunk.try_into().unwrap();
+            protein.push(translate_codon(codon).map_err(|e| match e {
+                TranslationError::MixedGapCodon { .. } => {
+                    TranslationError::MixedGapCodon { position: i * 3 }
+                }
+            })?);
+        } else {
+            // Partial codon at end -> X
+            protein.push(b'X');
+        }
     }
 
-    protein
+    Ok(protein)
 }
 
 #[cfg(test)]
@@ -81,37 +118,58 @@ mod tests {
     #[test]
     fn test_translate_codon() {
         // Standard codons
-        assert_eq!(translate_codon(b"ATG"), b'M'); // Start codon
-        assert_eq!(translate_codon(b"TAA"), b'*'); // Stop
-        assert_eq!(translate_codon(b"TAG"), b'*'); // Stop
-        assert_eq!(translate_codon(b"TGA"), b'*'); // Stop
-        assert_eq!(translate_codon(b"TTT"), b'F'); // Phe
-        assert_eq!(translate_codon(b"GGG"), b'G'); // Gly
+        assert_eq!(translate_codon(*b"ATG").unwrap(), b'M'); // Start codon
+        assert_eq!(translate_codon(*b"TAA").unwrap(), b'*'); // Stop
+        assert_eq!(translate_codon(*b"TAG").unwrap(), b'*'); // Stop
+        assert_eq!(translate_codon(*b"TGA").unwrap(), b'*'); // Stop
+        assert_eq!(translate_codon(*b"TTT").unwrap(), b'F'); // Phe
+        assert_eq!(translate_codon(*b"GGG").unwrap(), b'G'); // Gly
 
         // Case insensitive
-        assert_eq!(translate_codon(b"atg"), b'M');
-        assert_eq!(translate_codon(b"AtG"), b'M');
+        assert_eq!(translate_codon(*b"atg").unwrap(), b'M');
+        assert_eq!(translate_codon(*b"AtG").unwrap(), b'M');
 
         // U instead of T (RNA)
-        assert_eq!(translate_codon(b"AUG"), b'M');
+        assert_eq!(translate_codon(*b"AUG").unwrap(), b'M');
 
-        // Gaps
-        assert_eq!(translate_codon(b"A-G"), b'-');
-        assert_eq!(translate_codon(b"---"), b'-');
+        // All gaps
+        assert_eq!(translate_codon(*b"---").unwrap(), b'-');
 
         // Ambiguous bases
-        assert_eq!(translate_codon(b"ATN"), b'X');
-        assert_eq!(translate_codon(b"NNN"), b'X');
+        assert_eq!(translate_codon(*b"ATN").unwrap(), b'X');
+        assert_eq!(translate_codon(*b"NNN").unwrap(), b'X');
+    }
+
+    #[test]
+    fn test_translate_codon_mixed_gaps() {
+        // Mixed gaps should return error
+        assert!(translate_codon(*b"A-G").is_err());
+        assert!(translate_codon(*b"AT-").is_err());
+        assert!(translate_codon(*b"-TG").is_err());
+        assert!(translate_codon(*b"--G").is_err());
+        assert!(translate_codon(*b"A--").is_err());
     }
 
     #[test]
     fn test_translate_sequence() {
-        assert_eq!(translate_sequence(b"ATGTTT"), b"MF");
-        assert_eq!(translate_sequence(b"ATGTTTGGG"), b"MFG");
-        // Partial codon at end is truncated
-        assert_eq!(translate_sequence(b"ATGTTTT"), b"MF");
-        assert_eq!(translate_sequence(b"ATGTTTTT"), b"MF");
-        // Gaps
-        assert_eq!(translate_sequence(b"ATG---TTT"), b"M-F");
+        assert_eq!(translate_sequence(b"ATGTTT").unwrap(), b"MF");
+        assert_eq!(translate_sequence(b"ATGTTTGGG").unwrap(), b"MFG");
+        // Partial codon at end produces X
+        assert_eq!(translate_sequence(b"ATGTTTT").unwrap(), b"MFX");
+        assert_eq!(translate_sequence(b"ATGTTTTT").unwrap(), b"MFX");
+        // All-gap codons work
+        assert_eq!(translate_sequence(b"ATG---TTT").unwrap(), b"M-F");
+    }
+
+    #[test]
+    fn test_translate_sequence_mixed_gaps() {
+        // Mixed gaps in sequence should return error with correct position
+        let result = translate_sequence(b"ATGA-GTTT");
+        assert!(result.is_err());
+        if let Err(TranslationError::MixedGapCodon { position }) = result {
+            assert_eq!(position, 3); // Error at codon starting at position 3
+        } else {
+            panic!("Expected MixedGapCodon error");
+        }
     }
 }


### PR DESCRIPTION
Hey there-- 

I really love this program. Thanks so much for creating it! I'm submitting a small PR here to add a feature that I've created that's really useful for my workflows. The basic idea is I've added a translation toggle switch to `alen`

## Summary

  - Adds 't' key to toggle between DNA and translated protein views
  - Uses universal genetic code, assumes sequences are in-frame
  - Translation is computed lazily on first toggle

## Details

  - Gaps in codons translate to gaps in protein
  - Ambiguous bases (N, R, Y, etc.) translate to 'X'
  - Stop codons display as '*'
  - Search (Ctrl-f) works in both modes
  - Consensus is cleared when toggling (can re-enable with 'c')
  - Footer shows 't: Translate' hint for DNA alignments only

I'd be happy to modify this if you'd like more features (e.g., other genetic codes or reading frames) but as is, this is very useful to me and I figured I'd share. 

cheers